### PR TITLE
feat: 新增数据源选择设置器

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ import ArraySetter from './setter/array-setter';
 import ObjectSetter from './setter/object-setter';
 import VariableSetter from './setter/variable-setter';
 import TitleSetter from './setter/title-setter';
+import DataSourceSetter from './setter/datasource-setter';
 import EventBindDialog from './plugin/plugin-event-bind-dialog';
 import VariableBindDialog from './plugin/plugin-variable-bind-dialog';
 import './index.less';
@@ -193,6 +194,7 @@ const engineExt = {
     ArraySetter: DataArraySetter,
     ObjectSetter: DataObjectSetter,
     TitleSetter,
+    DataSourceSetter,
   },
 
   setterMap: {
@@ -222,6 +224,7 @@ const engineExt = {
     ArraySetter: DataArraySetter,
     ObjectSetter: DataObjectSetter,
     TitleSetter,
+    DataSourceSetter,
   },
 
   pluginMap: {

--- a/src/setter/datasource-setter/index.tsx
+++ b/src/setter/datasource-setter/index.tsx
@@ -1,0 +1,96 @@
+import React, { PureComponent } from 'react'; // import classNames from 'classnames';
+import { project, } from '@alilc/lowcode-engine';
+import { Select } from '@alifd/next'
+const { Option } = Select
+
+interface DataSourceItem {
+  id: string;
+  isInit?: boolean;
+  type?: string;
+  options?: {
+      uri: string;
+      params?: {};
+      method?: string;
+      shouldFetch?: string;
+      willFetch?: string;
+      fit?: string;
+      didFetch?: string;
+  };
+  dataHandler?: () => void;
+}
+
+interface DataSourceValue {
+  type: string;
+  value: string;
+}
+
+interface DataSourceProps {
+  value: DataSourceValue;
+  field: any;
+  onChange: (value: DataSourceValue) => void,
+}
+
+interface DataSourceState {
+  list: Array<DataSourceItem>;
+  value: string;
+}
+
+class DataSourceView extends PureComponent<DataSourceProps, DataSourceState> {
+
+  state: DataSourceState = {
+    list: [],
+    value: ''
+  }
+
+  componentDidMount() {
+    console.log('DataSourceProps', this.props)
+    const { field } = this.props
+    const target = field.getValue()  // props值
+    console.log(target)
+    const id = target?.value?.split('this.dataSourceMap.')[1]?.split(' ')[0] ?? ''  // 获取数据源id JSFunction方式
+
+    const exportSchema = project?.exportSchema()
+    this.setState({
+      list: exportSchema?.componentsTree[0]?.dataSource?.list ?? []  // 数据源列表
+    }, () => {
+      this.onChange(id)
+    })
+  }
+  onChange = (value: string) => {
+    console.log('onChange', value)
+    const { list } = this.state
+    const { onChange } = this.props  
+
+    if(!!value && !list.map(item => item.id).includes(value)) return  // 过滤传入的值不是数据源列表中
+    const propValue = {
+      type: 'JSFunction',  // js函数式类型 按容器组件内react写法写
+      value: !!value ? `function () { return this.dataSourceMap.${value} }` : ''
+    }
+    // 传递props参数
+    onChange(propValue)
+
+    this.setState({value})
+  }
+  render() {
+    const { value, list } = this.state
+    
+    return (
+      <Select
+        style={{width: '100%'}}
+        onChange={this.onChange}
+        value={value}
+      >
+        {list.map(item => <Option key={item.id} value={item.id}>{item.id}</Option>)}
+      </Select>
+    )
+  }
+}
+
+const DataSourceSetter = {
+  component: DataSourceView,
+  valueType: ['JSFunction'],
+  defaultProps: { placeholder: '请选择' },
+  recommend: true,
+};
+
+export default DataSourceSetter


### PR DESCRIPTION
# 数据源选择设置器

- 官方数据源plugin中配置数据源后，在数据源设置器中可获取到配置数据源列表，可直接通过选择的方式选择对应的数据源

- 数据源选择设置器中选择某个数据源后，prop传入的值为函数类型，返回值为选择数据源的实例，比如`function(){this.dataSourceMap.xxx}`

## 图例
<img width="348" alt="image" src="https://user-images.githubusercontent.com/40552704/173490354-39513cfa-760d-4f06-96fc-1b8ea7bfd9fa.png">
数据源plugin配置完数据源

<img width="390" alt="image" src="https://user-images.githubusercontent.com/40552704/173490446-b9af9350-9569-4978-93ad-fa77109a21d6.png">
数据源设置器中展示配置数据源下拉列表
