### PR TITLE
fix: save mixed used setter

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "module": "es/index.js",
   "stylePath": "style.js",
   "scripts": {
-    "start": "build-scripts start --config build.cloud.json",
+    "start": "build-scripts start --config build.cloud.json --port 4008",
     "build": "build-scripts build && build-scripts build --config build.cloud.json",
     "cloud-build": "build-scripts build --config build.cloud.json",
     "test": "build-scripts test",
@@ -70,5 +70,5 @@
     "registry": "https://registry.npmjs.org/"
   },
   "license": "MIT",
-  "homepage": "https://unpkg.com/@alilc/lowcode-engine-ext@1.0.2-beta.1/build/index.html"
+  "homepage": "https://unpkg.com/@alilc/lowcode-engine-ext@1.0.2-beta.2/build/index.html"
 }


### PR DESCRIPTION
将 MixedSetter 选择的 setter 缓存到 props 上，这样做原因是这是唯一一个现在能存取和同步到 schema 的方法
但需要避免 path 不同 name 相同的问题，所以整个存储 key 都需要 path 路径，另外在 key 前加上 _unsafe_ 前缀表示不安全属性，例如： 
"_unsafe_MixedSetter_config_0_disabled_select": "StringSetter"

后续 alc 提供合适的存储空间后，再将 syncSelectSetter 方法修复即可。