### PR TITLE
feat: fromMixedSetterSelect

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,4 +5,8 @@ module.exports = {
     'prettier/@typescript-eslint',
     'prettier/react',
   ],
+  rules: {
+    'react/no-multi-comp': 0,
+    '@typescript-eslint/member-ordering': 0,
+  },
 };

--- a/src/setter/mixed-setter/index.tsx
+++ b/src/setter/mixed-setter/index.tsx
@@ -133,6 +133,8 @@ export default class MixedSetter extends Component<{
   value?: any;
   className?: string;
 }> {
+  private fromMixedSetterSelect = false;
+
   private setters = nomalizeSetters(this.props.setters);
 
   // set name ,used in setting Transducer
@@ -160,13 +162,14 @@ export default class MixedSetter extends Component<{
     }
     return firstMatched || firstDefault || this.setters[0];
   }
+
   constructor(props) {
     super(props);
     // TODO: use engine ext.props
     const mixedKey = getMixedSelect(this.props.field);
     const usedSetter = this.props.field.node.getPropValue(mixedKey);
-    if(usedSetter) {
-      this.used = usedSetter
+    if (usedSetter) {
+      this.used = usedSetter;
     }
   }
 
@@ -174,6 +177,7 @@ export default class MixedSetter extends Component<{
   private hasVariableSetter = this.setters.some((item) => item.name === 'VariableSetter');
 
   private useSetter = (name: string, usedName: string) => {
+    this.fromMixedSetterSelect = true;
     const { field } = this.props;
     if (name === 'VariableSetter') {
       const setterComponent = getSetter('VariableSetter')?.component as any;
@@ -288,6 +292,7 @@ export default class MixedSetter extends Component<{
     }
 
     return createSetterContent(setterType, {
+      fromMixedSetterSelect: this.fromMixedSetterSelect,
       ...shallowIntl(setterProps),
       field,
       ...restProps,

--- a/src/setter/object-setter/index.tsx
+++ b/src/setter/object-setter/index.tsx
@@ -123,12 +123,13 @@ class RowSetter extends Component<RowSetterProps, RowSetterState> {
     });
   }
 
-  // shouldComponentUpdate(_: any, nextState: any) {
-  //   if (this.state.descriptor !== nextState.descriptor) {
-  //     return true;
-  //   }
-  //   return false;
-  // }
+  shouldComponentUpdate(_: any, nextState: any) {
+    if (this.state.descriptor !== nextState.descriptor) {
+      return true;
+    }
+    return false;
+  }
+
   private pipe: any;
 
   render() {


### PR DESCRIPTION
- 现有代码有很多都违反了两条 eslint 规则，先将这两个规则禁掉了（当然更合理的做法是把代码改掉，但是历史代码很难动）
- 给 mixed-setter 加了一个 fromMixedSetterSelect，使得 setter 可以知道自己是在 mixed-setter 被点开的（可以做一些特殊处理）
- 反注释掉之前 object-setter 的 shouldComponentUpdate（注释掉之后会引起 input 失焦）