### PR TITLE
fix: array-setter onRemove after add an empty item

### DIFF
--- a/src/setter/array-setter/index.tsx
+++ b/src/setter/array-setter/index.tsx
@@ -137,7 +137,7 @@ export class ListSetter extends Component<ArraySetterProps, ArraySetterState> {
   onRemove(removed: SettingField) {
     const { field } = this.props;
     const { items } = this.state;
-    const values = field.getValue();
+    const values = field.getValue() || [];
     let i = items.indexOf(removed);
     items.splice(i, 1);
     values.splice(i, 1);


### PR DESCRIPTION
When deleting an item immediately after adding it, field.getValue() will be undefined.