### PR TITLE
fix: EventSetter template does not take effect

### DIFF
--- a/src/plugin/plugin-event-bind-dialog/index.tsx
+++ b/src/plugin/plugin-event-bind-dialog/index.tsx
@@ -278,7 +278,7 @@ export default class EventBindDialog extends Component<PluginProps> {
       setTimeout(() => {
         event.emit('codeEditor.addFunction', {
           functionName: formatEventName,
-          templete: formatTemp,
+          template: formatTemp,
         });
       }, 200);
     }


### PR DESCRIPTION
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/17792166/176202896-5f58fe6f-ba94-4324-9180-6ee8a1f6bc12.png">

<img width="587" alt="image" src="https://user-images.githubusercontent.com/17792166/176203059-53e6e0c2-0640-4c3b-8ba0-a899f6fb8295.png">

@alilc/lowcode-plugin-code-editor 接受的参数是  template，源代码拼写有误

fixed: https://github.com/alibaba/lowcode-engine/issues/609