### PR TITLE
fix: date-picker onChange null

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,7 +55,7 @@ class StringDateSetter extends Component {
         value={moment(value)}
         showTime={showTime}
         onChange={(val) => {
-          onChange(val.format());
+          onChange(val ? val.format() : val);
         }}
       />
     );
@@ -70,7 +70,7 @@ class StringTimePicker extends Component {
       <TimePicker
         value={moment(value)}
         onChange={(val) => {
-          onChange(val.format('HH:mm:ss'));
+          onChange(val ? val.format('HH:mm:ss') : val);
         }}
       />
     );


### PR DESCRIPTION
修复清除时 `val` 为null引起的报错