### PR TITLE
fix: value not found

### DIFF
--- a/src/setter/mixed-setter/index.tsx
+++ b/src/setter/mixed-setter/index.tsx
@@ -360,7 +360,7 @@ export default class MixedSetter extends Component<{
               setterComponent.show({ prop: field });
             }}
           >
-            {intlNode('Binded: {expr}', { expr: field.getValue().value })}
+            {intlNode('Binded: {expr}', { expr: field.getValue()?.value ?? '-' })}
           </a>
         );
       } else {


### PR DESCRIPTION
fixed 1. 已绑定为空时的显示

<img width="1741" alt="image" src="https://user-images.githubusercontent.com/17792166/184112733-6a429530-5e0b-4ece-b85c-dc7fe5464912.png">

fixed 2.  value 不存在时，setter 渲染不出来

<img width="1775" alt="image" src="https://user-images.githubusercontent.com/17792166/184113052-f046e349-3740-4c17-a790-db6a88a5e596.png">


改完后变成如下：

1. 

<img width="1767" alt="image" src="https://user-images.githubusercontent.com/17792166/184113291-ae31c0ab-9987-4e80-9ba9-49cec24bdc14.png">

2. 没有 value is undefined 的报错了


