### PR TITLE
fix: mixed setter save old unsafe key when open

### DIFF
--- a/src/setter/mixed-setter/index.tsx
+++ b/src/setter/mixed-setter/index.tsx
@@ -40,9 +40,14 @@ function getMixedSelect(field) {
     newPath.splice(path.length - 1, 1, key);
     const newKey = field.node.getPropValue(newPath.join('.'))
     if(newKey) return newKey;
-    // 兼容下以前的问题情况
+    // 兼容下以前的问题情况，如果捕获到，获取 oldUnsafeKey 取值并将其直接置空
     const oldUnsafeKey = `_unsafe_MixedSetter${dash}${path.join(dash)}${dash}select`;
-    return field.node.getPropValue(oldUnsafeKey);
+    const oldUsedSetter = field.node.getPropValue(oldUnsafeKey);
+    if(oldUsedSetter) {
+      field.node.setPropValue(newPath.join('.'), oldUsedSetter);
+      field.node.setPropValue(oldUnsafeKey, undefined);
+    }
+    return oldUsedSetter;
   }
   return undefined;
 }


### PR DESCRIPTION
上一版本测试场景漏了。我们使用了很多 mixed setter，所以需要对老的 unsafe key 兼容，但上个版本的做法只 read 了一次，这样使用新版的时候只点开不修改的话，就不会做一次写正确的 key 的操作
这个版本如果读到老的 key，会做一次直接强写正确的 key 的操作，从操作上讲就是之前有问题的面板打开一次就会写到正常的结果。
但这个版本依然需要用户手动点到 mexid-setter 存在的那个层级（能执行到提交逻辑）才能保证正确，对老的 key 批量可能没办法了