### PR TITLE
fix: the slot setter switch state is lost after refreshing the page

### DIFF
--- a/src/setter/slot-setter/index.tsx
+++ b/src/setter/slot-setter/index.tsx
@@ -116,6 +116,7 @@ export default class SlotSetter extends Component<{
       switchComponent = (
         <Switch
           autoWidth
+          checked={!!value}
           defaultChecked={isOpenSlot}
           onChange={(checked) => this.onChangeSwitch(checked)}
           size="small"


### PR DESCRIPTION
复现步骤：

1.拖拽一个有插槽的组件，比如 https://lowcode-engine.cn/demo/demo-basic-fusion/index.html 下的 card 组件

2.选择插槽之后，打开开关

![image](https://user-images.githubusercontent.com/11935995/202952798-0e4b94c6-aec0-4dcf-a4ce-1564163670d6.png)

3.「刷新页面」 或者「选中其他节点，再选择 card 组件」发现开关状态为关闭状态