### PR TITLE
fix: optimize mixed setter, only reset value when setter is switched,…

### DIFF
--- a/src/setter/mixed-setter/index.tsx
+++ b/src/setter/mixed-setter/index.tsx
@@ -201,10 +201,17 @@ export default class MixedSetter extends Component<{
   private useSetter = (name: string, usedName: string) => {
     this.fromMixedSetterSelect = true;
     const { field } = this.props;
-    // reset value
-    field.setValue(undefined);
+    if (name !== this.used) {
+      // reset value
+      field.setValue(undefined);
+    }
     if (name === 'VariableSetter') {
       const setterComponent = getSetter('VariableSetter')?.component as any;
+      if (name !== this.used) {
+        field.setValue({
+          type: 'JSExpression'
+        });
+      }
       if (setterComponent && setterComponent.isPopup) {
         setterComponent.show({ prop: field });
         this.syncSelectSetter(name);


### PR DESCRIPTION
优化mixed setter：

1. 点击切换按钮如果设置器类型未改变也会重置field，调整为只在更改设置器类型后重置
2. 修复选择VariableSetter组件渲染状态和实际不一致的情况，增加了一个默认空值

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/1539586/220241852-19ee6d2c-8087-41f5-a13f-bb6c2b39d380.png">
