### PR TITLE
fix: start value has mixed support, consider using flex-start instead

### DIFF
--- a/src/setter/slot-setter/index.less
+++ b/src/setter/slot-setter/index.less
@@ -1,6 +1,6 @@
 .lc-setter-slot {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   .lc-slot-params {
     margin-top: 5px;
   }


### PR DESCRIPTION
编译器会报以下的错误：start value has mixed support, consider using flex-start instead 。修复一下警告，看着难受