### PR TITLE
fix: style setter add unit support

### DIFF
--- a/src/setter/style-setter/pro/layout/index.tsx
+++ b/src/setter/style-setter/pro/layout/index.tsx
@@ -11,6 +11,7 @@ interface layoutProps {
   styleData: StyleData | any;
   onStyleChange?: onStyleChange;
   layoutPropsConfig?: any;
+  unit?: string
 }
 
 const defaultLayoutPropsConfig = {
@@ -22,7 +23,7 @@ const defaultLayoutPropsConfig = {
 };
 
 export default (props: layoutProps) => {
-  const { onStyleChange, styleData, layoutPropsConfig } = props;
+  const { onStyleChange, styleData, layoutPropsConfig, unit } = props;
 
   // 配置合并
   const propsConfig = { ...defaultLayoutPropsConfig, ...layoutPropsConfig };
@@ -78,6 +79,7 @@ export default (props: layoutProps) => {
           styleData={styleData}
           onStyleChange={onStyleChange}
           layoutPropsConfig={propsConfig}
+          unit={unit}
         />
 
         {isShowWidthHeight && (

--- a/src/setter/style-setter/pro/layout/layoutBox.tsx
+++ b/src/setter/style-setter/pro/layout/layoutBox.tsx
@@ -11,7 +11,7 @@ const KEY_ARROW_UP = 'ArrowUp';
 interface layoutBoxProps {
   styleData: StyleData | any;
   onStyleChange: onStyleChange;
-  unit?: 'px';
+  unit?: string;
   layoutPropsConfig: any;
 }
 


### PR DESCRIPTION
将styleSetter 中 unit 透传到 LayoutBox中，
使LayoutBox中 margin/padding 所使用单位能与StyleSetter 联动

<img width="1871" alt="image" src="https://github.com/alibaba/lowcode-engine-ext/assets/32674989/0b0154a9-f035-4c18-bf12-55e36c0d1100">
