### PR TITLE
fix(variable-bind-dialog): state中value为false或者为空字符串也展示

### DIFF
--- a/src/plugin/plugin-variable-bind-dialog/index.tsx
+++ b/src/plugin/plugin-variable-bind-dialog/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Dialog, Input, Button, Icon ,Tree} from '@alifd/next';
+import { Dialog, Input, Button, Icon, Tree } from '@alifd/next';
 import { PluginProps } from '@alilc/lowcode-types';
 import { event, project } from '@alilc/lowcode-engine';
 import MonacoEditor from '@alilc/lowcode-plugin-base-monaco-editor';
@@ -21,7 +21,7 @@ field: '表单Field对象'
 
 const defaultEditorProps = {
   width: '100%',
-  height:'200px'
+  height: '200px',
 };
 
 const defaultEditorOption = {
@@ -57,17 +57,17 @@ export default class VariableBindDialog extends Component<PluginProps> {
     selParentVariable: null, // 选中的父级变量
     childrenVariableList: [], // 子级变量列表
     field: {}, // 编辑器全局变量
-    treeList:[],
+    treeList: [],
     minimize: false, // 是否最小化
     autoExpandParent: true,
-    expandedKeys:[],
+    expandedKeys: [],
   };
 
   private editorJsRef = React.createRef();
 
   private monocoEditor: any;
 
-  private matchedKeys:null;
+  private matchedKeys: null;
 
   get extraDataMap() {
     return this.props.config.props?.extraDataMap;
@@ -83,9 +83,9 @@ export default class VariableBindDialog extends Component<PluginProps> {
   }
 
   exportSchema = () => {
-     // 可以定制getSchema方法
-     return this.props.config?.props?.getSchema?.() || project.exportSchema();
-  }
+    // 可以定制getSchema方法
+    return this.props.config?.props?.getSchema?.() || project.exportSchema();
+  };
 
   initCode = () => {
     const { field } = this.state;
@@ -117,9 +117,9 @@ export default class VariableBindDialog extends Component<PluginProps> {
       if (Object.prototype.hasOwnProperty.call(methodsMap, key) && key) {
         // methods.push(`${key}()`);
         methods.push({
-          label:`${key}`,
+          label: `${key}`,
           key,
-        })
+        });
       }
     }
 
@@ -143,17 +143,18 @@ export default class VariableBindDialog extends Component<PluginProps> {
         dataSource.push(`this.state.${key}`);
         const valueString = stateMap[key].value;
         let value;
-        try{
+        try {
           value = eval(`(${valueString})`);
-        }catch(e){}
+        } catch (e) {}
 
-        if (value){
+        // 属性为false 或者 为"" 也显示到dialog中
+        if (value || value === false || value === '') {
           dataSourceMap[key] = value;
         }
       }
     }
     const treeList = [];
-    this.walkNode(dataSourceMap,-1,treeList);
+    this.walkNode(dataSourceMap, -1, treeList);
     // this.setState({
     //   treeList
     // })
@@ -168,18 +169,18 @@ export default class VariableBindDialog extends Component<PluginProps> {
    * @param path
    * @returns
    */
-  treeFindPath(tree, func, field = "", path = []) {
-    if (!tree) return []
+  treeFindPath(tree, func, field = '', path = []) {
+    if (!tree) return [];
     for (const data of tree) {
-      field === "" ? path.push(data) : path.push(data[field]);
-      if (func(data)) return path
+      field === '' ? path.push(data) : path.push(data[field]);
+      if (func(data)) return path;
       if (data.children) {
-        const findChildren = this.treeFindPath(data.children, func, field, path)
-        if (findChildren.length) return findChildren
+        const findChildren = this.treeFindPath(data.children, func, field, path);
+        if (findChildren.length) return findChildren;
       }
-      path.pop()
+      path.pop();
     }
-    return []
+    return [];
   }
 
   /**
@@ -188,16 +189,16 @@ export default class VariableBindDialog extends Component<PluginProps> {
    * @param deepNum
    * @param treeList
    */
-  walkNode (dataSourceMap,deepNum,treeList){
+  walkNode(dataSourceMap, deepNum, treeList) {
     deepNum++;
-    let index = 0
-    for (const key in dataSourceMap){
+    let index = 0;
+    for (const key in dataSourceMap) {
       const treeData = {};
       treeData.label = key;
       // treeData.key = deepNum+'_'+index;
-      if (typeof(dataSourceMap[key])==='object' && !(dataSourceMap[key] instanceof Array)){
+      if (typeof dataSourceMap[key] === 'object' && !(dataSourceMap[key] instanceof Array)) {
         treeData.children = [];
-        this.walkNode(dataSourceMap[key],deepNum,treeData.children);
+        this.walkNode(dataSourceMap[key], deepNum, treeData.children);
       }
       index++;
       treeList.push(treeData);
@@ -219,9 +220,9 @@ export default class VariableBindDialog extends Component<PluginProps> {
       if (item && item.id) {
         // dataSource.push(`this.state.${item.id}`);
         dataSource.push({
-          label:`${item.id}`,
-          key:item.id
-        })
+          label: `${item.id}`,
+          key: item.id,
+        });
       }
     }
 
@@ -383,13 +384,12 @@ export default class VariableBindDialog extends Component<PluginProps> {
     );
   };
 
-  handleExpand = (keys) =>{
+  handleExpand = (keys) => {
     this.setState({
       expandedKeys: keys,
-      autoExpandParent: false
+      autoExpandParent: false,
     });
-  }
-
+  };
 
   onVariableSearchChange = (value) => {
     this.setState({
@@ -408,8 +408,8 @@ export default class VariableBindDialog extends Component<PluginProps> {
     }
 
     const matchedKeys = [];
-    const loop = data =>
-      data.forEach(item => {
+    const loop = (data) =>
+      data.forEach((item) => {
         if (item.label.indexOf(value) > -1) {
           matchedKeys.push(item.key);
         }
@@ -420,10 +420,9 @@ export default class VariableBindDialog extends Component<PluginProps> {
     loop(selectedVariable.childrens);
     this.setState({
       expandedKeys: [...matchedKeys],
-      autoExpandParent: true
+      autoExpandParent: true,
     });
     this.matchedKeys = matchedKeys;
-
   };
 
   onVariableItemClick = (key: string) => {
@@ -462,30 +461,33 @@ export default class VariableBindDialog extends Component<PluginProps> {
     });
   };
 
-  onSelectTreeNode = (selectedKeys,extra) => {
-    const {selParentVariable,childrenVariableList} = this.state;
+  onSelectTreeNode = (selectedKeys, extra) => {
+    const { selParentVariable, childrenVariableList } = this.state;
 
     const label = extra.selectedNodes[0]?.props?.label;
     const key = extra.selectedNodes[0]?.key;
     let selectLabel;
-    if (selParentVariable == 'stateVaroableList'){
-      const pathList = this.treeFindPath(childrenVariableList,data=>(data.key==key),'label');
-      selectLabel = `this.state.${pathList.join('.')}`
-    }else if (selParentVariable == 'methods'){
+    if (selParentVariable == 'stateVaroableList') {
+      const pathList = this.treeFindPath(childrenVariableList, (data) => data.key == key, 'label');
+      selectLabel = `this.state.${pathList.join('.')}`;
+    } else if (selParentVariable == 'methods') {
       selectLabel = `${label}()`;
-    }else if (selParentVariable == 'dataSource'){
-      selectLabel = `this.state.${label}`
+    } else if (selParentVariable == 'dataSource') {
+      selectLabel = `this.state.${label}`;
     } else {
-      const fondKey = Object.keys(this.extraDataMap || {}).find(k => k === selParentVariable);
+      const fondKey = Object.keys(this.extraDataMap || {}).find((k) => k === selParentVariable);
       if (fondKey) {
         const propKey = this.extraDataMap[fondKey].key;
-        const pathList = this.treeFindPath(childrenVariableList, (data: any) => data.key === key,'label');
+        const pathList = this.treeFindPath(
+          childrenVariableList,
+          (data: any) => data.key === key,
+          'label',
+        );
         selectLabel = `this.${propKey}.${pathList.join('.')}`;
       }
     }
     this.onSelectItem(selectLabel);
-  }
-
+  };
 
   renderTitle = () => {
     return (
@@ -511,13 +513,11 @@ export default class VariableBindDialog extends Component<PluginProps> {
       searchValue,
       minimize,
       expandedKeys,
-      autoExpandParent
+      autoExpandParent,
     } = this.state;
 
-    const filterTreeNode = node => {
-      return (
-        this.matchedKeys && this.matchedKeys.indexOf(node.props.eventKey) > -1
-      );
+    const filterTreeNode = (node) => {
+      return this.matchedKeys && this.matchedKeys.indexOf(node.props.eventKey) > -1;
     };
 
     return (
@@ -566,9 +566,6 @@ export default class VariableBindDialog extends Component<PluginProps> {
                       </li>
                     );
                   })}
-
-
-
                 </ul>
                 <div className="vs-variable-selector-items-container">
                   <div className="ve-search-control">


### PR DESCRIPTION
修复变量绑定弹框中不展示state中value是空字符串和false的情况。只改了一行代码第151行，其他的是格式化代码
![image](https://github.com/alibaba/lowcode-engine-ext/assets/27946984/92ae53bd-e53c-4d85-b2b5-849ba60d1e84)
