### PR TITLE
feat(object-setter): 对象属性设置 popup支持属性控制 canCloseByOutSideClick，对象属性设置会唤起自己开发的plugin等操作，这时不希望点击popup外部时关闭

### DIFF
--- a/src/setter/object-setter/index.tsx
+++ b/src/setter/object-setter/index.tsx
@@ -38,6 +38,7 @@ export default class ObjectSetter extends Component<{
 interface ObjectSetterConfig {
   items?: IPublicTypeFieldConfig[];
   extraSetter?: IPublicTypeSetterType;
+  canCloseByOutSideClick: boolean;
 }
 
 interface RowSetterProps {
@@ -144,7 +145,10 @@ class RowSetter extends Component<RowSetterProps, RowSetterState> {
     const { field, config } = this.props;
 
     if (!this.pipe) {
-      this.pipe = (this.context as PopupPipe).create({ width: 320 });
+      this.pipe = (this.context as PopupPipe).create({
+        width: 320,
+        canCloseByOutSideClick: config.canCloseByOutSideClick
+      });
     }
 
     const title = (


### PR DESCRIPTION
例如下图，在ObjectSetter里面会使用自己开发的setter，该setter会通过事件唤起plugin等弹窗进行操作，这时候我不希望点击popup外部时就关闭，这样会导致setter组件卸载以及体验问题
![image](https://github.com/alibaba/lowcode-engine-ext/assets/28851987/6768c6d6-1c69-40bf-801f-66f4d8d01f01)
