### PR TITLE
fix: 修复参数绑定的缺失this.

### DIFF
--- a/src/plugin/plugin-variable-bind-dialog/index.tsx
+++ b/src/plugin/plugin-variable-bind-dialog/index.tsx
@@ -496,7 +496,7 @@ export default class VariableBindDialog extends Component<PluginProps> {
       const pathList = this.treeFindPath(childrenVariableList, (data) => data.key == key, 'label');
       selectLabel = `this.state.${pathList.join('.')}`;
     } else if (selParentVariable == 'methods') {
-      selectLabel = `${label}()`;
+      selectLabel = `this.${label}()`;
     } else if (selParentVariable == 'dataSource') {
       selectLabel = `this.state.${label}`;
     } else {


### PR DESCRIPTION
### 现状
<img width="1422" alt="image" src="https://github.com/alibaba/lowcode-engine-ext/assets/2155745/b7a4f24e-2540-4090-9054-155ded6336b2">

### 实际

<img width="1433" alt="image" src="https://github.com/alibaba/lowcode-engine-ext/assets/2155745/ea35254b-1a73-424d-af07-7c6787cb076e">

### 预期

点击后直接 getText()  -> this.getText()