### PR TITLE
chore: render solt

### DIFF
--- a/src/setter/mixed-setter/config.ts
+++ b/src/setter/mixed-setter/config.ts
@@ -1,0 +1,16 @@
+import { ReactNode } from "react"
+import { SettingField } from '@alilc/lowcode-engine';
+
+class MixedSetterConfig {
+  config: {
+    renderSlot?: (props: {bindCode?: string, field?: SettingField}) => ReactNode
+  } = {}
+
+  setConfig(config: {
+    renderSlot?: (props: {bindCode?: string, field?: SettingField}) => ReactNode
+  }) {
+    this.config = config;
+  }
+}
+
+export const MixedSetterController = new MixedSetterConfig()

--- a/src/setter/mixed-setter/index.less
+++ b/src/setter/mixed-setter/index.less
@@ -1,9 +1,9 @@
 .lc-setter-mixed {
   min-width: 0;
-  margin-right: 26px;
+  margin-right: 40px;
   display: block;
   position: relative;
-  width: 100%;
+  width: calc(100% - 20px);
   > .lc-setter-actions {
     position: absolute;
     right: -4px;
@@ -33,6 +33,13 @@
       }
     }
   }
+  >.lc-action-slot {
+    position: absolute;
+    display: flex;
+    right: -24px;
+    top: 50%;
+    transform: translate(100%, -50%);
+  }
   .next-input,
   .next-date-picker,
   .next-month-picker {
@@ -55,6 +62,11 @@
     right: 12px;
     top: 0;
     height: 32px;
+    transform: none;
+  }
+  >.lc-action-slot {
+    right: 12px;
+    top: 44px;
     transform: none;
   }
 }

--- a/src/setter/mixed-setter/index.tsx
+++ b/src/setter/mixed-setter/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ComponentClass, ReactNode } from 'react';
+import React, { Component, ComponentClass } from 'react';
 import classNames from 'classnames';
 import { Dropdown, Menu } from '@alifd/next';
 import { common, setters, SettingField } from '@alilc/lowcode-engine';
@@ -13,6 +13,7 @@ import {
 } from '@alilc/lowcode-types';
 import { IconConvert } from './icons/convert';
 import { intlNode } from './locale';
+import { MixedSetterController } from './config'
 
 import './index.less';
 import { IconVariable } from './icons/variable';
@@ -148,7 +149,7 @@ interface VariableSetter extends ComponentClass {
 }
 
 @observer
-export default class MixedSetter extends Component<{
+class MixedSetter extends Component<{
   field: SettingField;
   setters?: Array<string | SetterConfig | CustomView | DynamicSetter>;
   onSetterChange?: (field: SettingField, name: string) => void;
@@ -436,7 +437,7 @@ export default class MixedSetter extends Component<{
   }
 
   render() {
-    const { className } = this.props;
+    const { className, field } = this.props;
     let contents:
       | {
           setterContent: ReactNode;
@@ -468,7 +469,20 @@ export default class MixedSetter extends Component<{
       >
         {contents.setterContent}
         <div className="lc-setter-actions">{contents.actions}</div>
+        {!!MixedSetterController.config.renderSlot &&
+          <div className="lc-action-slot">
+            {MixedSetterController.config.renderSlot?.({
+              field,
+              bindCode: field.getValue()?.value,
+            })}
+          </div>
+        }
       </div>
     );
   }
 }
+interface MixedSetterType extends ComponentClass {
+  controller: typeof MixedSetterController;
+}
+export default MixedSetter as unknown as MixedSetterType
+(MixedSetter as unknown as MixedSetterType).controller = MixedSetterController;

--- a/src/setter/style-setter/components/css-code/locale/index.ts
+++ b/src/setter/style-setter/components/css-code/locale/index.ts
@@ -3,8 +3,8 @@ import enUS from './en-US.json';
 import zhCN from './zh-CN.json';
 
 const intlLocal = () => {
-  const { getLocale } = common.utils.createIntl();
-  const locale: string = getLocale() || 'zh-CN';
+  const { getLocale } = common.utils.createIntl?.() || {};
+  const locale: string = getLocale?.() || 'zh-CN';
   const localeSource: any = {
     'en-US': enUS,
     'zh-CN': zhCN,

--- a/src/setter/style-setter/index.tsx
+++ b/src/setter/style-setter/index.tsx
@@ -12,8 +12,8 @@ import zhCN from '@alifd/next/lib/locale/zh-cn';
 import { common } from '@alilc/lowcode-engine';
 import './index.less';
 
-const { getLocale } = common.utils.createIntl();
-const locale: string = getLocale() || 'zh-CN';
+const { getLocale } = common.utils.createIntl?.() || {};
+const locale: string = getLocale?.() || 'zh-CN';
 const localeSource: any = {
   'en-US': enUS,
   'zh-CN': zhCN,

--- a/src/setter/style-setter/pro/background/locale/index.ts
+++ b/src/setter/style-setter/pro/background/locale/index.ts
@@ -3,8 +3,8 @@ import enUS from './en-US.json';
 import zhCN from './zh-CN.json';
 
 const intlLocal = () => {
-  const { getLocale } = common.utils.createIntl();
-  const locale: string = getLocale() || 'zh-CN';
+  const { getLocale } = common.utils.createIntl?.() || {};
+  const locale: string = getLocale?.() || 'zh-CN';
   const localeSource: any = {
     'en-US': enUS,
     'zh-CN': zhCN,

--- a/src/setter/style-setter/pro/border/locale/index.ts
+++ b/src/setter/style-setter/pro/border/locale/index.ts
@@ -3,8 +3,8 @@ import enUS from './en-US.json';
 import zhCN from './zh-CN.json';
 
 const intlLocal = () => {
-  const { getLocale } = common.utils.createIntl();
-  const locale: string = getLocale() || 'zh-CN';
+  const { getLocale } = common.utils.createIntl?.() || {};
+  const locale: string = getLocale?.() || 'zh-CN';
   const localeSource: any = {
     'en-US': enUS,
     'zh-CN': zhCN,

--- a/src/setter/style-setter/pro/font/locale/index.ts
+++ b/src/setter/style-setter/pro/font/locale/index.ts
@@ -3,8 +3,8 @@ import enUS from './en-US.json';
 import zhCN from './zh-CN.json';
 
 const intlLocal = () => {
-  const { getLocale } = common.utils.createIntl();
-  const locale: string = getLocale() || 'zh-CN';
+  const { getLocale } = common.utils.createIntl?.() || {};
+  const locale: string = getLocale?.() || 'zh-CN';
   const localeSource: any = {
     'en-US': enUS,
     'zh-CN': zhCN,

--- a/src/setter/style-setter/pro/layout/locale/index.ts
+++ b/src/setter/style-setter/pro/layout/locale/index.ts
@@ -3,8 +3,8 @@ import enUS from './en-US.json';
 import zhCN from './zh-CN.json';
 
 const intlLocal = () => {
-  const { getLocale } = common.utils.createIntl();
-  const locale: string = getLocale() || 'zh-CN';
+  const { getLocale } = common.utils.createIntl?.() || {};
+  const locale: string = getLocale?.() || 'zh-CN';
   const localeSource: any = {
     'en-US': enUS,
     'zh-CN': zhCN,

--- a/src/setter/style-setter/pro/position/locale/index.ts
+++ b/src/setter/style-setter/pro/position/locale/index.ts
@@ -3,8 +3,8 @@ import enUS from './en-US.json';
 import zhCN from './zh-CN.json';
 
 const intlLocal = () => {
-  const { getLocale } = common.utils.createIntl();
-  const locale: string = getLocale() || 'zh-CN';
+  const { getLocale } = common.utils.createIntl?.() || {};
+  const locale: string = getLocale?.() || 'zh-CN';
   const localeSource: any = {
     'en-US': enUS,
     'zh-CN': zhCN,


### PR DESCRIPTION
在MixedSetter组件扩展了插槽，
可以拿到组件的 field 属性以及绑定的源码文本。
使用方法：
`
    const MixedSetterController = setterMap.MixedSetter.controller;
    MixedSetterController.setConfig({
      renderSlot: (props: any) => <LinkToCode {...props}/>
    });
`

以及修复了一些 intl 的 bug