### PR TITLE
fix: array setter如果添加一个新的item,拖拽这个item会导致内部包裹的其他setter的值不正确

### DIFF
--- a/src/setter/array-setter/index.tsx
+++ b/src/setter/array-setter/index.tsx
@@ -168,7 +168,7 @@ export class ListSetter extends Component<ArraySetterProps, ArraySetterState> {
           <Sortable itemClassName="lc-setter-list-card" onSort={this.onSort.bind(this)}>
             {items.map((field, index) => (
               <ArrayItem
-                key={field.id}
+                key={Math.random()}
                 scrollIntoView={scrollToLast && index === lastIndex}
                 field={field}
                 onRemove={this.onRemove.bind(this, field)}

--- a/src/setter/array-setter/sortable.tsx
+++ b/src/setter/array-setter/sortable.tsx
@@ -197,7 +197,7 @@ class Sortable extends Component<{
     const { className, itemClassName, children } = this.props;
     const items: Array<string | number> = [];
     const cards = Children.map(children, (child) => {
-      const id = child.key!;
+      const id = child.props.field.id!;
       items.push(id);
       return (
         <div key={id} data-id={id} className={classNames('lc-sortable-card', itemClassName)}>


### PR DESCRIPTION
bug现象

[](https://github.com/alibaba/lowcode-engine-ext/assets/6938179/f488e696-df31-44e1-8431-66e02533d5c3)




